### PR TITLE
Add template generation routes

### DIFF
--- a/controllers/templateController.js
+++ b/controllers/templateController.js
@@ -1,0 +1,44 @@
+const Template = require('../models/Template');
+const cloudinary = require('cloudinary').v2;
+
+exports.createTemplate = async (req, res) => {
+  try {
+    const template = await Template.create(req.body);
+    res.status(201).json({ success: true, template });
+  } catch (err) {
+    res.status(400).json({ success: false, error: err.message });
+  }
+};
+
+exports.getTemplates = async (req, res) => {
+  try {
+    const templates = await Template.find();
+    res.json({ success: true, templates });
+  } catch (err) {
+    res.status(500).json({ success: false, error: err.message });
+  }
+};
+
+exports.generateImage = async (req, res) => {
+  try {
+    const template = await Template.findById(req.params.id);
+    if (!template) return res.status(404).json({ success: false, message: 'Template not found' });
+
+    const transformations = template.overlays.map(o => ({
+      overlay: {
+        font_family: o.fontFamily,
+        font_size: o.fontSize,
+        text: req.body[o.field] || '',
+        color: o.fontColor
+      },
+      gravity: 'north_west',
+      x: o.x,
+      y: o.y
+    }));
+
+    const url = cloudinary.url(template.baseImage, { transformation: transformations });
+    res.json({ success: true, url });
+  } catch (err) {
+    res.status(500).json({ success: false, error: err.message });
+  }
+};

--- a/index.js
+++ b/index.js
@@ -62,6 +62,7 @@ app.use('/api/admissions', require('./routers/admissionRoutes'));
 app.use('/api/fees', require('./routers/feesRoutes'));
 app.use('/api/attendance', require('./routers/attendanceRoutes'));
 app.use('/api/dashboard-stats', require('./routers/dashboardStats'));
+app.use('/api/templates', require('./routers/templateRoutes'));
 
 
 // ✅ 404 fallback

--- a/models/Template.js
+++ b/models/Template.js
@@ -1,0 +1,18 @@
+const mongoose = require('mongoose');
+
+const overlaySchema = new mongoose.Schema({
+  field: { type: String, required: true },
+  x: { type: Number, required: true },
+  y: { type: Number, required: true },
+  fontFamily: { type: String, default: 'Arial' },
+  fontSize: { type: Number, default: 24 },
+  fontColor: { type: String, default: '#000000' }
+});
+
+const templateSchema = new mongoose.Schema({
+  name: { type: String, required: true },
+  baseImage: { type: String, required: true },
+  overlays: [overlaySchema]
+}, { timestamps: true });
+
+module.exports = mongoose.model('Template', templateSchema);

--- a/routers/templateRoutes.js
+++ b/routers/templateRoutes.js
@@ -1,0 +1,22 @@
+const express = require('express');
+const router = express.Router();
+const jwt = require('jsonwebtoken');
+const templateController = require('../controllers/templateController');
+
+const verifyToken = (req, res, next) => {
+  const token = req.headers.authorization?.split(' ')[1];
+  if (!token) return res.status(401).json({ error: 'No token provided' });
+  try {
+    const decoded = jwt.verify(token, process.env.JWT_SECRET);
+    req.user = decoded;
+    next();
+  } catch {
+    res.status(401).json({ error: 'Invalid token' });
+  }
+};
+
+router.post('/', verifyToken, templateController.createTemplate);
+router.get('/', verifyToken, templateController.getTemplates);
+router.post('/:id/generate', verifyToken, templateController.generateImage);
+
+module.exports = router;


### PR DESCRIPTION
## Summary
- allow saving template data in MongoDB
- add controller for template CRUD and generation
- secure template routes with JWT verification
- expose `/api/templates` endpoint

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6873ebbb9ba88322a100fff4af2e7f2c